### PR TITLE
PATCH body params were not making it all the way through

### DIFF
--- a/examples/sample-app/lib/RESTApp/Host.pm
+++ b/examples/sample-app/lib/RESTApp/Host.pm
@@ -51,6 +51,16 @@ resource hosts => sub {
             { data => UseCase::Host::edit($params->{id}, %$params) }
         };
 
+        summary 'Edit a host';
+        params(
+            required => { name => 'state', type => Str, desc => 'Host state' },
+        );
+        patch sub {
+            my $params = shift;
+            { data => UseCase::Host::edit($params->{id}, %$params) }
+        };
+
+
         summary 'Delete a host';
         del sub {
             my $params = shift;

--- a/examples/sample-app/lib/RESTApp/User.pm
+++ b/examples/sample-app/lib/RESTApp/User.pm
@@ -58,6 +58,15 @@ resource users => sub {
             my $params = shift;
             { data => UseCase::User::edit($params->{id}, %$params) }
         };
+        summary 'Edit a user';
+        params(
+            optional => { name => 'password', type => Str, desc => 'User password' },
+            optional => { name => 'email', type => Str, desc => 'User email' },
+        );
+        patch sub {
+            my $params = shift;
+            { data => UseCase::User::edit($params->{id}, %$params) }
+        };
 
         desc 'Bump a user';
         resource bump => sub {
@@ -71,6 +80,12 @@ resource users => sub {
             summary 'Bump a user';
             tags 'users', 'bump';
             put sub {
+                my $params = shift;
+                { success => UseCase::User::bump($params->{id}) }
+            };
+            summary 'Bump a user';
+            tags 'users', 'bump';
+            patch sub {
                 my $params = shift;
                 { success => UseCase::User::bump($params->{id}) }
             };

--- a/lib/Raisin/Request.pm
+++ b/lib/Raisin/Request.pm
@@ -66,7 +66,7 @@ sub prepare_params {
 
     # Serialization / Deserialization
     my $body_params = do {
-        if ($self->method =~ /POST|PUT/ && (my $content = $self->content)) {
+        if ($self->method =~ /POST|PUT|PATCH/ && (my $content = $self->content)) {
             if ($self->content_type =~ m{application/x-www-form-urlencoded}imsx) {
                 $self->body_parameters->as_hashref_mixed;
             }

--- a/t/integration/app-routes.t
+++ b/t/integration/app-routes.t
@@ -10,7 +10,7 @@ use Test::More;
 use YAML 'Load';
 use JSON 'decode_json';
 
-use lib ("$Bin/../../examples/sample-app/lib");
+use lib ("$Bin/../../lib", "$Bin/../../examples/sample-app/lib");
 
 my $app = Plack::Util::load_psgi("$Bin/../../examples/sample-app/script/restapp.psgi");
 

--- a/t/integration/app-routes.t
+++ b/t/integration/app-routes.t
@@ -10,7 +10,7 @@ use Test::More;
 use YAML 'Load';
 use JSON 'decode_json';
 
-use lib ("$Bin/../../lib", "$Bin/../../examples/sample-app/lib");
+use lib ("$Bin/../../examples/sample-app/lib");
 
 my $app = Plack::Util::load_psgi("$Bin/../../examples/sample-app/script/restapp.psgi");
 


### PR DESCRIPTION
i.e. 
```
params(
    optional => { name => 'last_name', type => Str }
);
patch sub {
    my $params = shift;
}
```

$params would be empty, but after some debugging I found they were in req->body_parameters

Unfortunately, HTTP::Request::Common does not support PATCH, so I had to add my own PATCH method to the test file to get by.