### PR TITLE
Fix for delayed responses and streaming body.

### DIFF
--- a/lib/Raisin.pm
+++ b/lib/Raisin.pm
@@ -137,7 +137,7 @@ sub psgi {
         $self->swagger_build_spec;
     }
 
-    eval {
+    my $ret = eval {
         $self->hook('before')->($self);
 
         # Find a route
@@ -204,6 +204,9 @@ sub psgi {
         $res->render_500($msg);
     };
 
+    if(ref($ret) eq 'CODE') {
+        return $ret;
+    }
     $self->finalize;
 }
 


### PR DESCRIPTION
A comment in Raisin::psgi noted that delayed reponses are untested.
From the code I guessed the intention was that if the route handler returns a code ref, this should be returned from the PSGI handler, so that the standard delayed/streaming behavior is triggered ([PSGI spec](https://metacpan.org/pod/distribution/PSGI/PSGI.pod#Delayed-Response-and-Streaming-Body)).

However, the code ref is only returned from the "eval" but not from the PSGI handler. Hence, with this tiny patch delayed/streaming responses work for me.