### PR TITLE
Example for how the json encoding could be influenced

### DIFF
--- a/lib/Raisin/Encoder/JSON.pm
+++ b/lib/Raisin/Encoder/JSON.pm
@@ -5,10 +5,12 @@ use warnings;
 
 use JSON qw(encode_json decode_json);
 
+our $json = JSON->new()->utf8();
+
 sub detectable_by { [qw(application/json text/x-json text/json json)] }
 sub content_type { 'application/json' }
-sub serialize { encode_json($_[1]) }
-sub deserialize { decode_json($_[1]) }
+sub serialize { $json->encode($_[1]) }
+sub deserialize { $json->decode($_[1]) }
 
 1;
 
@@ -21,6 +23,16 @@ Raisin::Encoder::JSON - JSON serialization plugin for Raisin.
 =head1 DESCRIPTION
 
 Provides C<content_type>, C<serialize> methods.
+
+=head1 ADJUST ENCODER
+
+The $Raisin::Encoder::JSON::json variable is the object used for encoding and decoding.
+
+Therefore you can tweak the encoding (and decoding like so)
+
+ $Raisin::Encoder::JSON::json->pretty(1);
+ $Raisin::Encoder::JSON::json->indent(1);
+ etc...
 
 =head1 AUTHOR
 


### PR DESCRIPTION
This is a small example of how the json encoding could be influenced by the developer using Raisin.

Its probably too specific to JSON encoding, perhaps a method called *encoder* or something could be provided which always returns the object?