### PR TITLE
Respect content-type from `provides` route annotations

### DIFF
--- a/lib/Raisin.pm
+++ b/lib/Raisin.pm
@@ -109,7 +109,8 @@ sub run {
         default_format => $self->default_format,
         format => $self->format,
         decoder => $self->decoder,
-        encoder => $self->encoder
+        encoder => $self->encoder,
+        raisin => $self,
     );
 
     # load fallback logger (Raisin::Logger)

--- a/t/behaviour/app-serialize-provides.t
+++ b/t/behaviour/app-serialize-provides.t
@@ -1,0 +1,91 @@
+
+use strict;
+use warnings;
+
+use Data::Dumper;
+use HTTP::Request::Common qw(GET);
+use Plack::Test;
+use Test::More;
+use YAML;
+use JSON;
+
+use Raisin::API;
+use Types::Standard qw(Int Str);
+
+my $BINARY_DATA = "DUMMY\{0}BINARY\{0}BLOB\{0}";
+
+{
+    # no-op encoder that responds to certain content types
+    package Test::Encoder::Blob;
+    sub detectable_by { [qw(application/blob blob)] }
+    sub content_type  { 'x-application/blob' }
+
+    sub serialize   { $_[1] }
+    sub deserialize { $_[1] }
+
+    # Appease Plack::Util->load_class
+    $INC{'Test/Encoder/Blob.pm'} = 1;
+}
+
+my $app = eval {
+    resource blob => sub {
+        produces [ 'blob' ];
+        get sub { $BINARY_DATA };
+    };
+    register_encoder('blob' => 'Test::Encoder::Blob');
+    run;
+};
+
+{
+    no strict 'refs';
+    no warnings qw(once redefine);
+    *Raisin::log = sub { note(sprintf $_[1], @_[2 .. $#_]) };
+}
+
+BAIL_OUT $@ if $@;
+
+subtest 'via Accept' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET '/blob', Accept => 'application/blob');
+
+        is $res->code, 200, 'status';
+        is $res->content, $BINARY_DATA, 'content';
+        is $res->content_type, 'x-application/blob', 'content type';
+    };
+};
+
+subtest 'via Accept */*' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET '/blob', Accept => 'application/xml, */*');
+
+        is $res->code, 200, 'status';
+        is $res->content, $BINARY_DATA, 'content';
+        is $res->content_type, 'x-application/blob', 'content type';
+    };
+};
+
+subtest 'via Extension' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET '/blob.blob');
+
+        is $res->code, 200, 'status';
+        is $res->content, $BINARY_DATA, 'content';
+        is $res->content_type, 'x-application/blob', 'content type';
+    };
+};
+
+
+subtest 'unacceptable' => sub {
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET '/blob', Accept => 'application/json');
+
+        is $res->code, 406, 'status';
+    };
+};
+
+
+done_testing;

--- a/t/unit/middleware/formatter.t
+++ b/t/unit/middleware/formatter.t
@@ -277,11 +277,10 @@ subtest 'format_from_header' => sub {
 
     for my $c (@CASES) {
         my $fmt = Raisin::Middleware::Formatter->new(
-            default_format => $DEFAULT_FORMAT,
             encoder => Raisin::Encoder->new
         );
 
-        my @h = $fmt->format_from_header($c->{header});
+        my @h = $fmt->format_from_header($c->{header}, $DEFAULT_FORMAT);
         is_deeply \@h, $c->{expected}, join('>', @{ $c->{expected} }) || 'NONE';
     }
 };


### PR DESCRIPTION
Formatter middleware now respects `provides` annotation for routes and
uses it both as default and as a restriction  on allowed response
content types.

This makes it possible to for ex. output binary blobs on specific paths,
while keeping the rest of the paths as structured data.

To acheive this, we needed to make the following changes:

* `Raisin::Middleware::Formatter` is now aware of the running Raisin app
(via `raisin` attribute)

* `::Formatter->negotiate_format` method has gained a new parmeter to
allow for picking the proper default when `provides` is configured and
`Accept: */*` header is sent