### PR TITLE
Correct longmess call bug

### DIFF
--- a/lib/Raisin.pm
+++ b/lib/Raisin.pm
@@ -206,7 +206,7 @@ sub psgi {
 
         1;
     } or do {
-        my $e = longmess($@);
+        my ($e) = longmess($@);
         $self->log(error => $e);
 
         my $msg = $ENV{PLACK_ENV}


### PR DESCRIPTION
longmess() returns an array when the exception is a blessed object.  Raisin was calling this in scalar context, resulting in $e set to '1'.  By calling longmess() in list context, we can properly handle the return value(s).