### PR TITLE
Fix swagger route

### DIFF
--- a/lib/Raisin/Routes.pm
+++ b/lib/Raisin/Routes.pm
@@ -95,7 +95,7 @@ sub find {
         ? $self->cache->{$cache_key}
         : $self->routes;
 
-    my @found = grep { $_->match($method, $path) } @$routes;
+    my @found = grep { $_->match($method, $path) } @$routes or return;
 
     if (scalar @found > 1) {
         Raisin::log(warn => "more then one route has been found: $method $path");


### PR DESCRIPTION
We discovered that the route to fetch the Swagger for the API broke in commit c06323360c13fecfdb09b4575aa19de0d496b91c.   What this looks like is the first request for the swagger returns a 404 Not Found, and this ends up getting cached in Raisin.  You can see this for yourself using the example REST app.  E.g.:

```shell
plackup ./examples/sample-app/script/restapp.psgi
```
Then try to fetch the swagger using `/api/swagger`:

```
$ http --json http://localhost:5000/api/swagger
HTTP/1.0 404 Not Found
...
```

Note that you can request it at a different URI to avoid hitting the cache and it resolves with the second request:

```
$ http --json http://localhost:5000/api/swagger.json 
HTTP/1.0 200 OK
Content-Length: 8005
Content-Type: application/json
...
```
This PR avoids the problem by not caching the result if no routes match the request.