### PR TITLE
Detect missing comma and give clearer error.

### DIFF
--- a/lib/Raisin/API.pm
+++ b/lib/Raisin/API.pm
@@ -77,7 +77,11 @@ sub after { app->add_hook('after', shift) }
 # Resource
 #
 sub resource {
-    my ($name, $code, %args) = @_;
+    my ($name, $code, @args) = @_;
+    if (scalar(@args) % 2) {
+        croak "Odd-sized hash supplied to resource(). Is the previous resource missing a semicolon?";
+    }
+    my %args = @args;
 
     if ($name) {
         $name =~ s{^/}{}msx;

--- a/t/unit/api.t
+++ b/t/unit/api.t
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception;
 
 use Raisin::API;
 use Raisin::Entity::Object;
@@ -285,6 +286,16 @@ subtest 'error' => sub {
     is $res->status, 501, 'status';
     is $res->body, 'Unit test!', 'body';
 
+    _clean_app();
+};
+
+subtest 'resource_bad' => sub {
+    throws_ok {
+         resource l0 => sub {
+              resource l1a => sub {}, # should be semicolon, not comma!
+              resource l1b => sub {};
+         };
+    } qr/missing a semicolon/, "Bad comma caught";
     _clean_app();
 };
 


### PR DESCRIPTION
Hello,

We've been getting some warnings caused by a comma rather than a semicolon after a `resource`. Surprisingly, this typo does not appear to to cause any harm beyond a warning. I have added a check to `resource()` to die with a more helpful error.

The test I have added appears to break other tests if not placed last. I am unsure why.