### PR TITLE
Fix references to Test::Exception in cpanfile (missing close quotes)

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -23,11 +23,11 @@ requires 'HTTP::Status' => '0';
 on test => sub {
     requires 'Test::More' => '0.88';
     requires 'List::Util' => '1.29';
-    requires 'Test::Exception => '0';
+    requires 'Test::Exception' => '0';
 };
 
 on develop => sub {
     requires 'Data::Printer' => '0.35';
     requires 'List::Util' => '1.29';
-    requires 'Test::Exception => '0';
+    requires 'Test::Exception' => '0';
 };


### PR DESCRIPTION
Text::Exception in cpanfile was missing closing quotes,  resulthing in the following when trying to install with Carton:
```
! Parsing /home/perl/Raisin/cpanfile failed: syntax error at /home/jwright/Raisin/cpanfile line 26, near "'Test::Exception => '0"
Successfully installed Test-Pod-1.52
Successfully installed JSON-4.02
! Configuring Raisin-0.79 failed. See /home/jwright/.cpanm/work/1563980472.30192/build.log for details.
2 distributions installed
Installing modules failed

```
This PR corrects the file

