### PR TITLE
Make prepare_params return a false value if any param validation fails

### DIFF
--- a/lib/Raisin/Request.pm
+++ b/lib/Raisin/Request.pm
@@ -22,11 +22,14 @@ sub prepare_params {
 
     $self->{'raisin.parameters'} = \%params;
 
+    my $retval = 1;
+
     foreach my $p (@$declared) {
         my $name = $p->name;
         my $value = $params{$name};
 
         if (not $p->validate(\$value)) {
+            $retval = 0;
             $p->required ? return : next;
         }
 
@@ -36,7 +39,7 @@ sub prepare_params {
         $self->{'raisin.declared_params'}{$name} = $value;
     }
 
-    1;
+    $retval;
 }
 
 sub declared_params { shift->{'raisin.declared_params'} }

--- a/t/unit/request.t
+++ b/t/unit/request.t
@@ -5,7 +5,7 @@ use warnings;
 use HTTP::Message::PSGI;
 use HTTP::Request::Common qw(GET);
 use Test::More;
-use Types::Standard qw(Int);
+use Types::Standard qw(Int Enum);
 
 use Raisin;
 use Raisin::Param;
@@ -94,6 +94,10 @@ subtest 'validation' => sub {
                 type => 'optional',
                 spec => { name => 'opt2', type => Int, default => 42 },
             ),
+            Raisin::Param->new(
+                type => 'optional',
+                spec => { name => 'opt3', type => Enum[qw(one two)] },
+            ),
         ],
         code => sub {},
     );
@@ -136,6 +140,14 @@ subtest 'validation' => sub {
             expected => {
                 ret => 1,
                 pp => { req => 1, opt2 => 2 },
+            },
+        },
+        # Optional Enum with bad enum value
+        {
+            env => GET('/user/?req=1&opt3=bad')->to_psgi,
+            expected => {
+                ret => 0,
+                pp => { req => 1 }
             },
         },
     );


### PR DESCRIPTION
Previously, if an optional param failed to valid, this still returned a
true value.  This was problematic if you had an "optional" param that
has a type constraint such as Enum.

Fixes #85