### PR TITLE
Support enum values in swagger plugin

### DIFF
--- a/lib/Raisin/Plugin/Swagger.pm
+++ b/lib/Raisin/Plugin/Swagger.pm
@@ -261,6 +261,12 @@ sub _parameters_object {
             $ptype->{schema}{'$ref'} = delete $ptype->{'$ref'};
         }
 
+        # If the type is an Enum, set type to string and give the enum values.
+        if (_type_is_enum($p->type)) {
+            $ptype->{type} = 'string';
+            $ptype->{enum} = $p->type->values;
+        }
+
         my %param = (
             description => $p->desc || '',
             in          => $location,
@@ -468,6 +474,15 @@ sub _name_for_object {
     #--- $ref values must be RFC3986 compliant URIs ---
     $objname =~ s/::/-/g;
     sprintf '%s-%s', $objname, uc(substr($fingerprint, 0, 10));
+}
+
+sub _type_is_enum {
+    my $type = shift;
+
+    return 1 if $type->isa('Moose::Meta::TypeConstraint::Enum')
+             or $type->isa('Type::Tiny::Enum');
+
+    return 0;
 }
 
 1;

--- a/t/unit/plugin/swagger.t
+++ b/t/unit/plugin/swagger.t
@@ -4,7 +4,7 @@ use warnings;
 
 use JSON::MaybeXS;
 use Test::More;
-use Types::Standard qw/HashRef ArrayRef Str/;
+use Types::Standard qw/HashRef ArrayRef Str Enum/;
 
 use Raisin;
 use Raisin::Param;
@@ -132,6 +132,27 @@ my @PARAMETERS_CASES = (
                 name => 'str',
                 required => JSON::MaybeXS::true,
                 type => 'string',
+            }
+        ]
+    },
+    {
+        method => 'POST',
+        params => [
+            Raisin::Param->new(
+                named => 0,
+                type  => 'required',
+                spec  => { name => 'enum', type => Enum[qw(foo bar)], default => 'foo', in => 'body' },
+            )
+        ],
+        expected => [
+            {
+                default => 'foo',
+                description => '',
+                in => 'body',
+                name => 'enum',
+                required => JSON::MaybeXS::true,
+                type => 'string',
+                enum => [ qw( bar foo ) ],
             }
         ]
     },

--- a/t/unit/plugin/swagger.t
+++ b/t/unit/plugin/swagger.t
@@ -146,13 +146,13 @@ my @PARAMETERS_CASES = (
         ],
         expected => [
             {
-                default => 'foo',
+                default     => 'foo',
                 description => '',
-                in => 'body',
-                name => 'enum',
-                required => JSON::MaybeXS::true,
-                type => 'string',
-                enum => [ qw( bar foo ) ],
+                in          => 'body',
+                name        => 'enum',
+                required    => JSON::MaybeXS::true,
+                type        => 'string',
+                enum        => [ qw( bar foo ) ],
             }
         ]
     },

--- a/t/unit/plugin/swagger/moose.t
+++ b/t/unit/plugin/swagger/moose.t
@@ -1,0 +1,52 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Raisin;
+use Raisin::Param;
+use Raisin::Plugin::Swagger;
+
+BEGIN {
+    unless (eval { require Moose::Util::TypeConstraints; 1 }) {
+        plan skip_all => 'This test requires Moose::Util::TypeConstraints';
+    }
+
+    Moose::Util::TypeConstraints->import('enum');
+}
+
+my @PARAMETERS_CASES = (
+    {
+        method => 'POST',
+        params => [
+            Raisin::Param->new(
+                named => 0,
+                type  => 'required',
+                spec  => { name => 'enum', type => enum([qw(foo bar)]), default => 'foo', in => 'body' },
+            )
+        ],
+        expected => [
+            {
+                default     => 'foo',
+                description => '',
+                in          => 'body',
+                name        => 'enum',
+                required    => JSON::MaybeXS::true,
+                type        => 'string',
+                enum        => [ qw( foo bar ) ],
+            }
+        ]
+    },
+);
+
+for my $case (@PARAMETERS_CASES) {
+    my $obj = Raisin::Plugin::Swagger::_parameters_object(
+        $case->{method},
+        $case->{params}
+    );
+
+    is_deeply $obj, $case->{expected},
+        "$case->{method} $case->{expected}[0]{in} $case->{expected}[0]{name}";
+}
+
+done_testing;


### PR DESCRIPTION
This PR detects enums that are either made from `Types::Standard::Enum`, or `enum()` from `Moose::Util::TypeConstraints`, and sets the swagger type to `type: string` and adds `enum: [ ... all possible values ]` to the generated swagger.