### PR TITLE
Fix handing of wide characters / UTF-8

### DIFF
--- a/lib/Raisin/Encoder/JSON.pm
+++ b/lib/Raisin/Encoder/JSON.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use JSON::MaybeXS qw();
 
-my $json = JSON::MaybeXS->new();
+my $json = JSON::MaybeXS->new(utf8 => 1);
 
 sub detectable_by { [qw(application/json text/x-json text/json json)] }
 

--- a/lib/Raisin/Encoder/YAML.pm
+++ b/lib/Raisin/Encoder/YAML.pm
@@ -3,12 +3,13 @@ package Raisin::Encoder::YAML;
 use strict;
 use warnings;
 
+use Encode qw(encode_utf8 decode_utf8);
 use YAML qw(Dump Load);
 
 sub detectable_by { [qw(application/x-yaml application/yaml text/x-yaml text/yaml yaml)] }
 sub content_type { 'application/x-yaml' }
-sub serialize { Dump($_[1]) }
-sub deserialize { Load($_[1]) }
+sub serialize { encode_utf8( Dump($_[1]) ) }
+sub deserialize { Load( decode_utf8($_[1]) ) }
 
 1;
 

--- a/t/behaviour/app-serialize.t
+++ b/t/behaviour/app-serialize.t
@@ -1,21 +1,24 @@
 
+use utf8;
 use strict;
 use warnings;
 
 use Data::Dumper;
+use Encode qw(decode_utf8);
 use HTTP::Request::Common qw(GET);
 use Plack::Test;
 use Test::More;
-use YAML;
+use YAML qw(Load);
 use JSON::MaybeXS;
 
 use Raisin::API;
 use Types::Standard qw(Int Str);
 
 my %DATA = (
-    name => 'Bruce Wayne',
+    name     => 'Bruce Wayne',
     password => 'b47m4n',
-    email => 'bruce@wayne.name',
+    email    => 'bruce@wayne.name',
+    enemy    => "Mr \x{2603}",
 );
 
 my $app = eval {
@@ -42,14 +45,14 @@ test_psgi $app, sub {
 
         is $res->header('Content-Type'), 'application/x-yaml',
           'content-type';
-        ok $pp = Load( $res->content ), 'decode';
+        ok $pp = Load( decode_utf8($res->content) ), 'decode';
         is_deeply $pp->{params}, \%DATA, 'match';
 
         $res = $cb->( GET '/api.yaml' );
 
         is $res->header('Content-Type'), 'application/x-yaml',
           'content-type';
-        ok $pp = Load( $res->content ), 'decode';
+        ok $pp = Load( decode_utf8($res->content) ), 'decode';
         is_deeply $pp->{params}, \%DATA, 'match';
     };
 


### PR DESCRIPTION
We now expect JSON and YAML input to be UTF-8 encoded, and encode wide
characters to UTF-8 bytes on output for JSON and YAML encoders.  Without
this, if you return a data structure with wide characters, the response
will blow up because HTTP::Message will croak if the content is not
encoded as bytes.

Fixes #88