### PR TITLE
Added support for dynamic changes to content type.

### DIFF
--- a/lib/Raisin/Middleware/Formatter.pm
+++ b/lib/Raisin/Middleware/Formatter.pm
@@ -57,6 +57,12 @@ sub call {
         my $res = shift;
         my $r = Plack::Response->new(@$res);
 
+        # The application may decide on the fly to return a different
+        # content type than we negotiated above. In that case it becomes
+        # responsible for updating $env appropriately, and also
+        # specifying the encoder to use.
+        my $format = $env->{'raisinx.encoder'};
+
         # If the body is a data structure of some sort, finalize it now,
         # BUT NOT if it's a file handle (broadly construed). In that case
         # treat it as a deferred response.


### PR DESCRIPTION
Raisin selects a response content type (and hence an Encoder) based on the "Accept" header of the request and the "produces" list for the resource. Applications can change the Content-Type header, but can't change the encoder. This patch changes Raisin's post-processing step to consult the 'raisinx.encoder' value in the attribute, which may have changed since it was initially set by the call() method.

This is a minimal change: the application is fully responsible for making sure the headers are consistent, that the new content-type is appropriate, and that the specified encoder actually exists. It just gives you the power to change the encoder, if you need to and know what you're doing.